### PR TITLE
prevent + signs from being valid in email address (temporary fix)

### DIFF
--- a/src/components/Info/Form.js
+++ b/src/components/Info/Form.js
@@ -79,7 +79,8 @@ export default ({ onSubmit, city }) => {
           required
           id="email"
           type="email"
-          pattern="[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,4}$"
+          // TODO: re-add + sign as a valid pattern before the @ symbol
+          pattern="[a-z0-9._%-]+@[a-z0-9.-]+\.[a-z]{2,4}$"
           value={email}
           onInvalid={e => e.target.setCustomValidity(`Please provide a valid e-mail address.`)}
           onChange={e => setEmail(e.target.value.trim())}


### PR DESCRIPTION
There is an issue where the plus sign is not being properly encoded for airtable. As a temporary measure I've updated the RegEx used to validate e-mail addresses to now allow plus signs until https://github.com/react-ladies/React-Ladies/issues/67 is resolved.